### PR TITLE
reintroduce controller and only handle external redirects within the model

### DIFF
--- a/controllers/redirect.php
+++ b/controllers/redirect.php
@@ -1,0 +1,25 @@
+<?php
+
+return function($site, $pages, $page) {
+
+  if ($page->redirect()->isNotEmpty() && ($p = page($this->redirect()->value()))) {
+    // if 'redirect to page' is set (and exists), go for it
+    $redirect = $p->redirect()->url();
+  }
+  elseif (!$page->external()->empty()) {
+    // if 'external url' is set, go for it
+    $redirect = $page->external()->value();
+  }
+  elseif ($page->children()->visible()->count()) {
+    // else if page has visible children, redirect to the first one
+    $redirect = $page->children()->visible()->first()->url();
+  }
+  else {
+    // fallback: redirect to homepage
+    $redirect = $site->homePage()->url();
+  }
+
+  return array(
+    'redirect' => $redirect,
+  );
+};

--- a/controllers/redirect.php
+++ b/controllers/redirect.php
@@ -6,7 +6,7 @@ return function($site, $pages, $page) {
     // if 'redirect to page' is set (and exists), go for it
     $redirect = $p->redirect()->url();
   }
-  elseif (!$page->external()->empty()) {
+  elseif ($page->external()->isNotEmpty()) {
     // if 'external url' is set, go for it
     $redirect = $page->external()->value();
   }

--- a/models/redirect.php
+++ b/models/redirect.php
@@ -3,18 +3,10 @@
 class RedirectPage extends Page {
 
   public function url() {
-    if ($this->redirect()->isNotEmpty() && ($p = page($this->redirect()->value()))) {
-      // if 'redirect to page' is set (and exists), go for it
-      return $p->url();
-    } else if ($this->external()->isNotEmpty()) {
-      // if 'external url' is set, go for it
-      return $this->external();
-    } elseif ($this->children()->visible()->count()) {
-      // else if page has visible children, redirect to the first one
-      return $this->children()->visible()->first()->url();
+    if ($this->isExternal()) {
+      return $this->external()->value();
     }
-    // fallback: redirect to homepage
-    return site()->homepage()->url();
+    return parent::url();
   }
 
   public function isExternal() {

--- a/redirect.php
+++ b/redirect.php
@@ -3,6 +3,9 @@
 // register blueprints
 $kirby->set('blueprint', 'redirect', __DIR__ . DS . 'blueprints' . DS . 'redirect.yml');
 
+// register controllers
+$kirby->set('controller', 'redirect', __DIR__ . DS . 'controllers' . DS . 'redirect.php');
+
 // register templates
 $kirby->set('template', 'redirect', __DIR__ . DS . 'templates' . DS . 'redirect.php');
 

--- a/templates/redirect.php
+++ b/templates/redirect.php
@@ -1,1 +1,1 @@
-<?php go($page->url()); ?>
+<?php go($redirect); ?>


### PR DESCRIPTION
Hey there,
as mentioned in my previous pull request #2, I found a recursion issue with redirects to the first child page. 
I found a solution for this issue but I am afraid it means, we have to reintroduce the controller ;)

Now only the external redirect url is handled in the redirect page model and everything else is done in the controller. This still achieves that the absolute external url is used in the menu, which was the issue with the original implementation I wanted to fix. I may have been a little to eager ;)

I am really sorry for the inconvienience. Hope this fixes everything. 
